### PR TITLE
Use .command_name which is introduced since groonga-command 1.2.3

### DIFF
--- a/lib/groonga/query-log/analyzer/reporter/console.rb
+++ b/lib/groonga/query-log/analyzer/reporter/console.rb
@@ -216,7 +216,7 @@ module Groonga
 
         def report_parameters(statistic)
           command = statistic.command
-          write("  name: <#{command.name}>\n")
+          write("  name: <#{command.command_name}>\n")
           write("  parameters:\n")
           command.arguments.each do |key, value|
             write("    <#{key}>: <#{value}>\n")

--- a/lib/groonga/query-log/command/extract.rb
+++ b/lib/groonga/query-log/command/extract.rb
@@ -172,7 +172,7 @@ module Groonga
         end
 
         def target?(command)
-          name = command.name
+          name = command.command_name
           target_commands = @options.commands
           exclude_commands = @options.exclude_commands
 


### PR DESCRIPTION
This commit makes Travis-CI test case green again.