### PR TITLE
Feature/add new option

### DIFF
--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -177,16 +177,37 @@ module Groonga
           directory_options.merge(options)
         end
 
+        def groonga_options(options)
+          groonga_options = Hash[*options]
+
+          filter = %w[
+            --server-id
+            --document-root
+            --cache-limit
+            --max-threads
+            --default-request-timeout
+            --memcached-column
+            --cache-base-path
+            --log-level
+            --log-rotate-threshold
+            --query-log-rotate-threshold
+            --config-path
+            --default-command-version
+            --default-match-escalation-threshold
+          ]
+          groonga_options.keep_if{|k,v| filter.include?(k)}
+        end
+
         def old_groonga_server
           GroongaServer.new(@old_groonga,
-                            @old_groonga_options,
+                            groonga_options(@old_groonga_options),
                             @old_database,
                             server_options)
         end
 
         def new_groonga_server
           GroongaServer.new(@new_groonga,
-                            @new_groonga_options,
+                            groonga_options(@new_groonga_options),
                             @new_database,
                             server_options)
         end
@@ -213,11 +234,9 @@ module Groonga
               "--protocol", "http",
               "--log-path", log_path.to_s,
             ]
-
-            @groonga_options.each{|groonga_option|
-              arguments << groonga_option
+            @groonga_options.each{|name, value|
+              arguments.concat([name, value])
             }
-
             if @options[:output_query_log]
               arguments.concat(["--query-log-path", query_log_path.to_s])
             end

--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -97,11 +97,10 @@ module Groonga
             @old_groonga = groonga
           end
 
-          parser.separator("")
-          parser.separator("Old Groonga Option:")
-          parser.on("--old-groonga-option=GROONGA_OPTION",
-                    "Old groonga option",
-                    "(#{@old_groonga_options})") do |groonga_option|
+          parser.on("--old-groonga-option=OPTION",
+                    "Add an additional old groonga option",
+                    "You can specify this option multiple times to specify multiple groonga options",
+                    "(no options)") do |groonga_option|
             @old_groonga_options << groonga_option
           end
 
@@ -113,11 +112,10 @@ module Groonga
             @new_groonga = groonga
           end
 
-          parser.separator("")
-          parser.separator("New Groonga Option:")
-          parser.on("--new-groonga-option=GROONGA_OPTION",
-                    "New groonga option",
-                    "(#{@new_groonga_options})") do |groonga_option|
+          parser.on("--new-groonga-option=OPTION",
+                    "Add an additional new groonga option",
+                    "You can specify this option multiple times to specify multiple groonga options",
+                    "(no options)") do |groonga_option|
             @new_groonga_options << groonga_option
           end
 
@@ -177,37 +175,16 @@ module Groonga
           directory_options.merge(options)
         end
 
-        def groonga_options(options)
-          groonga_options = Hash[*options]
-
-          filter = %w[
-            --server-id
-            --document-root
-            --cache-limit
-            --max-threads
-            --default-request-timeout
-            --memcached-column
-            --cache-base-path
-            --log-level
-            --log-rotate-threshold
-            --query-log-rotate-threshold
-            --config-path
-            --default-command-version
-            --default-match-escalation-threshold
-          ]
-          groonga_options.keep_if{|k,v| filter.include?(k)}
-        end
-
         def old_groonga_server
           GroongaServer.new(@old_groonga,
-                            groonga_options(@old_groonga_options),
+                            @old_groonga_options,
                             @old_database,
                             server_options)
         end
 
         def new_groonga_server
           GroongaServer.new(@new_groonga,
-                            groonga_options(@new_groonga_options),
+                            @new_groonga_options,
                             @new_database,
                             server_options)
         end
@@ -228,15 +205,12 @@ module Groonga
           def run
             return unless @options[:run_queries]
 
-            arguments = [
-              "--bind-address", @host,
-              "--port", @port.to_s,
-              "--protocol", "http",
-              "--log-path", log_path.to_s,
-            ]
-            @groonga_options.each{|name, value|
-              arguments.concat([name, value])
-            }
+            arguments = @groonga_options.dup
+            
+            arguments.concat(["--bind-address", @host])
+            arguments.concat(["--port", @port.to_s])
+            arguments.concat(["--protocol", "http"])
+            arguments.concat(["--log-path", log_path.to_s])
             if @options[:output_query_log]
               arguments.concat(["--query-log-path", query_log_path.to_s])
             end

--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -34,9 +34,11 @@ module Groonga
 
           @old_groonga = "groonga"
           @old_database = "db.old/db"
+          @old_groonga_options = []
 
           @new_groonga = "groonga"
           @new_database = "db.new/db"
+          @new_groonga_options = []
 
           @recreate_database = false
           @load_data = true
@@ -96,11 +98,27 @@ module Groonga
           end
 
           parser.separator("")
+          parser.separator("Old Groonga Option:")
+          parser.on("--old-groonga-option=GROONGA_OPTION",
+                    "Old groonga option",
+                    "(#{@old_groonga_options})") do |groonga_option|
+            @old_groonga_options << groonga_option
+          end
+
+          parser.separator("")
           parser.separator("New Groonga:")
           parser.on("--new-groonga=GROONGA",
                     "New groonga command",
                     "(#{@new_groonga})") do |groonga|
             @new_groonga = groonga
+          end
+
+          parser.separator("")
+          parser.separator("New Groonga Option:")
+          parser.on("--new-groonga-option=GROONGA_OPTION",
+                    "New groonga option",
+                    "(#{@new_groonga_options})") do |groonga_option|
+            @new_groonga_options << groonga_option
           end
 
           parser.separator("")
@@ -161,22 +179,25 @@ module Groonga
 
         def old_groonga_server
           GroongaServer.new(@old_groonga,
+                            @old_groonga_options,
                             @old_database,
                             server_options)
         end
 
         def new_groonga_server
           GroongaServer.new(@new_groonga,
+                            @new_groonga_options,
                             @new_database,
                             server_options)
         end
 
         class GroongaServer
           attr_reader :host, :port
-          def initialize(groonga, database_path, options)
+          def initialize(groonga, groonga_options, database_path, options)
             @input_directory = options[:input_directory] || Pathname.new(".")
             @working_directory = options[:working_directory] || Pathname.new(".")
             @groonga = groonga
+            @groonga_options = groonga_options
             @database_path = @working_directory + database_path
             @host = "127.0.0.1"
             @port = find_unused_port
@@ -192,6 +213,11 @@ module Groonga
               "--protocol", "http",
               "--log-path", log_path.to_s,
             ]
+
+            @groonga_options.each{|groonga_option|
+              arguments << groonga_option
+            }
+
             if @options[:output_query_log]
               arguments.concat(["--query-log-path", query_log_path.to_s])
             end


### PR DESCRIPTION
現在のgroonga-query-log-run-regression-testは、実行するgroongaにオプションを与えて実行できないため、groongaにオプションを与えた状態での回帰テストはできませんでした。

上記の問題を解決するため、groonga-query-log-run-regression-testに以下の新しいオプションを追加しました。

* --old-groonga-option
* --new-groonga-option

追加したオプションの使用方法は以下の通りです。
<pre>
#古いgroongaにオプションを与える場合。
--old-groonga-option=<オプション名>
--old-groonga-option=<値>

#新しいgroongaにオプションを与える場合。
--new-groonga-option=<オプション名>
--new-groonga-option=<値>

    ・--old-groonga-option、--new-groonga-optionは複数回使用することができます。
    ・複数のオプションを設定したい場合は、設定したいオプションの数だけ
        --old-groonga-option、--new-groonga-optionを使ってgroongaに与えるオプションを
        記載してください。
</pre>

<pre>
例)
新しいgroongaに --default-request-timeout 10.0と--cache-base-path /tmp/local/cache/cacheを
設定して回帰テストを行う場合は以下のように記載します。

groonga-query-log-run-regression-test --new-groonga=/usr/local/new_groonga/bin/groonga \
--new-groonga-option=--default-request-timeout --new-groonga-option=10.0 \
--new-groonga-option=--cache-base-path --new-groonga-option=/tmp/local/cache/cache \
-- old-groonga=/usr/local/old_groonga/bin/groonga
</pre>

また、--new-groonga-option、--old-groonga-optionで指定可能なgroongaのオプションは以下の通りです。
<pre>
--server-id
--document-root
--cache-limit
--max-threads
--default-request-timeout
--memcached-column
--cache-base-path
--log-level
--log-rotate-threshold
--query-log-rotate-threshold
--config-path
--default-command-version
--default-match-escalation-threshold
</pre>