### PR TITLE
Add target command name in `server-verifier.rb`.

### DIFF
--- a/lib/groonga/query-log/server-verifier.rb
+++ b/lib/groonga/query-log/server-verifier.rb
@@ -164,6 +164,7 @@ module Groonga
             "normalize",
             "object_exist",
             "select",
+            "status",
           ]
           @care_order = true
         end


### PR DESCRIPTION
回帰テストで永続化キャッシュのテストを行う際、キャッシュヒット率をログに記録するため、テストの最後に`status`のクエリを実行したいのですが、現状、`status`は、回帰テストで実行できるコマンドに含まれていないため、`status`のクエリを実行しても、結果が戻ってきませんでした。

上記の課題を解決するため、回帰テストで実行できるコマンドに`status`コマンドを追加しました。