### PR TITLE
Add feature that verify cache hit rate. 

### DIFF
--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -46,6 +46,7 @@ module Groonga
           @skip_finished_queries = false
           @output_query_log = false
           @care_order = true
+          @verify_cachehit_mode = false
         end
 
         def run(command_line)
@@ -145,6 +146,10 @@ module Groonga
                     "Don't care order of select response records") do
             @care_order = false
           end
+          parser.on("--verify-cachehit-mode",
+                    "Verify cachehit rate. After execute all query, 'status' command execute.") do
+            @verify_cachehit_mode = true
+          end
 
           parser
         end
@@ -216,7 +221,6 @@ module Groonga
             arguments << "-s"
             arguments << @database_path.to_s
             @pid = spawn(@groonga, *arguments)
-
             n_retries = 10
             begin
               send_command("status")
@@ -408,6 +412,7 @@ module Groonga
             ]
             command_line << "--no-care-order" if @options[:care_order] == false
             command_line << query_log_path.to_s
+            command_line << "--verify-cachehit-mode" if @new.use_persistent_cache? or @old.use_persistent_cache?
             verify_server = VerifyServer.new
             verify_server.run(command_line)
           end

--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -217,6 +217,7 @@ module Groonga
             arguments << "-s"
             arguments << @database_path.to_s
             @pid = spawn(@groonga, *arguments)
+
             n_retries = 10
             begin
               send_command("status")

--- a/lib/groonga/query-log/command/run-regression-test.rb
+++ b/lib/groonga/query-log/command/run-regression-test.rb
@@ -146,10 +146,6 @@ module Groonga
                     "Don't care order of select response records") do
             @care_order = false
           end
-          parser.on("--verify-cachehit-mode",
-                    "Verify cachehit rate. After execute all query, 'status' command execute.") do
-            @verify_cachehit_mode = true
-          end
 
           parser
         end

--- a/lib/groonga/query-log/command/verify-server.rb
+++ b/lib/groonga/query-log/command/verify-server.rb
@@ -54,6 +54,7 @@ module Groonga
 
           available_protocols = [:gqtp, :http]
           available_protocols_label = "[#{available_protocols.join(', ')}]"
+
           parser.on("--groonga1-host=HOST",
                     "Host name or IP address of Groonga server 1",
                     "[#{@options.groonga1.host}]") do |host|

--- a/lib/groonga/query-log/command/verify-server.rb
+++ b/lib/groonga/query-log/command/verify-server.rb
@@ -54,7 +54,6 @@ module Groonga
 
           available_protocols = [:gqtp, :http]
           available_protocols_label = "[#{available_protocols.join(', ')}]"
-
           parser.on("--groonga1-host=HOST",
                     "Host name or IP address of Groonga server 1",
                     "[#{@options.groonga1.host}]") do |host|
@@ -133,6 +132,12 @@ module Groonga
                     "Output results to PATH",
                     "[stdout]") do |path|
             @options.output_path = path
+          end
+
+          parser.on("--verify-cachehit-mode",
+                    "Verify cachehit rate. After execute query, 'status' command execute.",
+                    "[#{@options.verify_cachehit_mode}]") do
+            @options.verify_cachehit_mode = true
           end
 
           parser.separator("Debug options:")

--- a/lib/groonga/query-log/response-comparer.rb
+++ b/lib/groonga/query-log/response-comparer.rb
@@ -36,6 +36,8 @@ module Groonga
           case @command.name
           when "select", "logical_select"
             same_select_response?
+          when "status"
+            same_cache_hit_rate?
           else
             same_response?
           end
@@ -69,6 +71,10 @@ module Groonga
         else
           same_size_response?
         end
+      end
+
+      def same_cache_hit_rate?
+        @response1.body["cache_hit_rate"] == @response2.body["cache_hit_rate"]
       end
 
       def care_order?

--- a/lib/groonga/query-log/server-verifier.rb
+++ b/lib/groonga/query-log/server-verifier.rb
@@ -109,7 +109,7 @@ module Groonga
       end
 
       def verify_command(groonga1_client, groonga2_client, command)
-        if command == Groonga::Command::Status
+        if command.instance_of?(Groonga::Command::Status)
           return unless @options.verify_cachehit_mode
         end
         command["cache"] = "no" if @options.disable_cache?

--- a/lib/groonga/query-log/server-verifier.rb
+++ b/lib/groonga/query-log/server-verifier.rb
@@ -78,6 +78,9 @@ module Groonga
               begin
                 verify_command(groonga1_client, groonga2_client,
                                statistic.command)
+
+                verify_command(groonga1_client, groonga2_client,
+                               Groonga::Command::Status.new)
               rescue
                 log_client_error($!) do
                   $stderr.puts(statistic.command.original_source)
@@ -106,6 +109,9 @@ module Groonga
       end
 
       def verify_command(groonga1_client, groonga2_client, command)
+        if command == Groonga::Command::Status
+          return unless @options.verify_cachehit_mode
+        end
         command["cache"] = "no" if @options.disable_cache?
         command["output_type"] = :json
         response1 = groonga1_client.execute(command)
@@ -148,6 +154,7 @@ module Groonga
         attr_accessor :target_command_names
         attr_accessor :output_path
         attr_accessor :care_order
+        attr_accessor :verify_cachehit_mode
         def initialize
           @groonga1 = GroongaOptions.new
           @groonga2 = GroongaOptions.new
@@ -167,6 +174,7 @@ module Groonga
             "status",
           ]
           @care_order = true
+          @verify_cahehit_mode = false
         end
 
         def request_queue_size

--- a/lib/groonga/query-log/server-verifier.rb
+++ b/lib/groonga/query-log/server-verifier.rb
@@ -164,6 +164,7 @@ module Groonga
             "normalize",
             "object_exist",
             "select",
+            "status",
           ]
           @care_order = true
         end


### PR DESCRIPTION
永続化キャッシュのテスト用にキャッシュヒット率を検証するための機能を追加しました。
追加した機能は以下の通りです。
* `--cache-base-path`オプションが付与されたgroongaを定期的に再起動します。
    * 再起動のタイミングは、`query-logs/`配下のlogファイル実行毎に1度行います。
        * `query-logs/`配下に6ファイルあれば、6回再起動されます。
* 新旧いずれかのgroongaに`--cache-base-path`オプションが付与された場合に、1クエリー実行毎に1回`status`コマンドを実行します。
    * 実行した`status`コマンドの`cache_hit_rate`の値を比較し、異なっている場合は、`status`コマンドの結果を`results/`配下に出力します。