### PR TITLE
Add missing version

### DIFF
--- a/lib/groonga/query-log/command/detect-memory-leak.rb
+++ b/lib/groonga/query-log/command/detect-memory-leak.rb
@@ -18,6 +18,7 @@
 
 require "optparse"
 
+require "groonga/query-log/version"
 require "groonga/query-log/memory-leak-detector"
 
 module Groonga


### PR DESCRIPTION
Without this change, it causes uninitialized constant error.

  detect-memory-leak.rb:45:in `create_parser': uninitialized constant Groonga::QueryLog::Command::DetectMemoryLeak::VERSION (NameError)
        from /home/kenhys/work/groonga/groonga-query-log.work/lib/groonga/query-log/command/detect-memory-leak.rb:32:in `run'