### PR TITLE
Add missing version

### DIFF
--- a/lib/groonga/query-log/command/replay.rb
+++ b/lib/groonga/query-log/command/replay.rb
@@ -18,6 +18,7 @@
 
 require "optparse"
 
+require "groonga/query-log/version"
 require "groonga/query-log/replayer"
 
 module Groonga


### PR DESCRIPTION
Without this change, it causes uninitialized constant.

  lib/groonga/query-log/command/replay.rb:45:in `create_parser': uninitialized constant Groonga::QueryLog::Command::Replay::VERSION (NameError)
        from /home/kenhys/work/groonga/groonga-query-log.work/lib/groonga/query-log/command/replay.rb:32:in `run'
        from ./bin/groonga-query-log-replay:23:in `<main>'