### PR TITLE
response-comparer: Modify to ignore the difference in accuracy of float values

### DIFF
--- a/lib/groonga-query-log/response-comparer.rb
+++ b/lib/groonga-query-log/response-comparer.rb
@@ -68,7 +68,11 @@ module GroongaQueryLog
           same_response?
         end
       else
-        same_size_response?
+        if same_location_information?
+          same_size_response?
+        else
+          false
+        end
       end
     end
 
@@ -117,6 +121,19 @@ module GroongaQueryLog
         columns1.sort_by(&:first) == columns2.sort_by(&:first)
       else
         columns1 == columns2
+      end
+    end
+
+    def same_location_information?
+      if @response1.body[0][1].flatten.include?("float")
+        location_information1 =
+          @response1.body.flatten.select {|e| e.class == Float}
+        location_information2 =
+          @response2.body.flatten.select {|e| e.class == Float}
+
+        location_information1[0].round(12) == location_information2[0].round(12)
+      else
+        true
       end
     end
 

--- a/test/test-response-comparer.rb
+++ b/test/test-response-comparer.rb
@@ -306,6 +306,14 @@ class ResponseComparerTest < Test::Unit::TestCase
       end
     end
 
+    class CareDifferencesInAccuracyOfPosition < self
+      def test_different_accurancy_of_postion
+        assert_true(same?([[[1], [["_id", "UInt32"],["location", "float"]], [1, 139.763570507358]]],
+                          [[[1], [["_id", "UInt32"],["location", "float"]], [1, 139.7635705073576]]],
+                          :care_order => false))
+      end
+    end
+
     class ErrorTest < self
       def test_with_location
         response1_header = [


### PR DESCRIPTION
Because of the difference in accuracy of float values between before and after Groonga v6.0.4.