### PR TITLE
run-regression-test: fix a wrong variable name

### DIFF
--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -326,7 +326,7 @@ module GroongaQueryLog
               command = [
                 @groonga,
                 "--log-path", log_path.to_s,
-                "--file", grn_file.to_s,
+                "--file", load_file.to_s,
                 @database_path.to_s,
               ]
             end


### PR DESCRIPTION
Because grn_file is undefined.