### PR TITLE
run-regression-test: support HTTP error case

### DIFF
--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -33,13 +33,13 @@ module GroongaQueryLog
 
     def verify(input, &callback)
       @same = true
-      @client_error = false
+      @client_error_is_occurred = false
       producer = run_producer(input, &callback)
       reporter = run_reporter
       producer.join
       @different_results.push(nil)
       reporter.join
-      @same and !@client_error
+      @same and !@client_error_is_occurred
     end
 
     private
@@ -51,7 +51,7 @@ module GroongaQueryLog
         n_commands = 0
         callback_per_n_commands = 100
         parser.parse(input) do |statistic|
-          break if (!@same or @client_error) and @options.stop_on_failure?
+          break if (!@same or @client_error_is_occurred) and @options.stop_on_failure?
 
           command = statistic.command
           next if command.nil?
@@ -100,7 +100,7 @@ module GroongaQueryLog
               log_client_error($!) do
                 $stderr.puts(original_source)
               end
-              @client_error = true
+              @client_error_is_occurred = true
               return false
             end
             if @options.verify_cache?
@@ -111,7 +111,7 @@ module GroongaQueryLog
                 log_client_error($!) do
                   $stderr.puts("status after #{original_source}")
                 end
-                @client_error = true
+                @client_error_is_occurred = true
                 return false
               end
             end

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -39,7 +39,7 @@ module GroongaQueryLog
       producer.join
       @different_results.push(nil)
       reporter.join
-      @same and !@client_error_is_occurred
+      different_or_error_results?
     end
 
     private
@@ -134,6 +134,10 @@ module GroongaQueryLog
 
     def target_command?(command)
       @options.target_command_name?(command.command_name)
+    end
+
+    def  different_or_error_results?
+      @same and !@client_error_is_occurred
     end
 
     def verify_command(groonga1_client, groonga2_client, command)

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -79,7 +79,7 @@ module GroongaQueryLog
       @options.n_clients.times.collect do
         Thread.new do
           loop do
-            break if run_consumer
+            break if run_consumer_stop?
           end
         end
       end
@@ -136,8 +136,12 @@ module GroongaQueryLog
       @options.target_command_name?(command.command_name)
     end
 
-    def  different_or_error_results?
+    def different_or_error_results?
       @same and !@client_error_is_occurred
+    end
+
+    def run_consumer_stop?
+      run_consumer or @options.stop_on_failure?
     end
 
     def verify_command(groonga1_client, groonga2_client, command)

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -51,7 +51,7 @@ module GroongaQueryLog
         n_commands = 0
         callback_per_n_commands = 100
         parser.parse(input) do |statistic|
-          break if (!@same or @client_error_is_occurred) and @options.stop_on_failure?
+          break if stop_parse?
 
           command = statistic.command
           next if command.nil?
@@ -138,6 +138,10 @@ module GroongaQueryLog
 
     def different_or_error_results?
       @same and !@client_error_is_occurred
+    end
+
+    def stop_parse?
+      (!@same or @client_error_is_occurred) and @options.stop_on_failure?
     end
 
     def run_consumer_stop?


### PR DESCRIPTION
Improve "stop-on-failure" option so as to stop the execution of tests even when causing HTTP errors.