### PR TITLE
run-regression-test: add notification support by E-Mail

### DIFF
--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -71,7 +71,6 @@ module GroongaQueryLog
         @smtp_auth_password = nil
         @smtp_starttls = false
         @smtp_port = 25
-
       end
 
       def run(command_line)
@@ -666,7 +665,6 @@ module GroongaQueryLog
       end
 
       class MailNotifier
-
         def initialize(success, elapsed_time, options)
           @success = success
           @elapsed_time = elapsed_time

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -725,6 +725,7 @@ Date: #{Time.now.rfc2822}
 
 #{body}
           MAIL
+          return if @options[:skip_smtp]
           smtp = Net::SMTP.new(@options[:smtp_server], @options[:smtp_port])
           smtp.enable_starttls if @options[:smtp_starttls]
           smtp.start(@options[:smtp_server],

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -682,13 +682,9 @@ module GroongaQueryLog
 
           subject = @options[:mail_subject_on_success]
           content = format_elapsed_time
-          if @tester_result
-            content << "Done."
-          else
-            subject = @options[:mail_subject_on_failure]
-            content << "Report:"
-            content << format_log
-          end
+          subject = @options[:mail_subject_on_failure]
+          content << "Report:"
+          content << format_log
           send_mail(subject, content)
         end
 

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -20,9 +20,13 @@ require "socket"
 require "fileutils"
 require "pathname"
 require "net/http"
+require "net/smtp"
+require "time"
+require "base64"
 
 require "groonga-query-log"
 require "groonga-query-log/command/verify-server"
+require "groonga-query-log/command/format-regression-test-logs"
 
 module GroongaQueryLog
   module Command
@@ -57,6 +61,17 @@ module GroongaQueryLog
         @target_command_names = ServerVerifier::Options.new.target_command_names
 
         @read_timeout = Groonga::Client::Default::READ_TIMEOUT
+
+        @mail_subject_on_success = "Success"
+        @mail_subject_on_failure = "Failure"
+        @mail_from = "groonga-query-log@#{Socket.gethostname}"
+        @mail_to = nil
+        @smtp_server = "localhost"
+        @smtp_auth_user = nil
+        @smtp_auth_password = nil
+        @smtp_starttls = false
+        @smtp_port = 25
+
       end
 
       def run(command_line)
@@ -68,10 +83,18 @@ module GroongaQueryLog
           return false
         end
 
+        @start_time = Time.now
         tester = Tester.new(old_groonga_server,
                             new_groonga_server,
                             tester_options)
-        tester.run
+        success = tester.run
+
+        if notifier_options[:mail_to]
+          notifier = MailNotifier.new(success, Time.now - @start_time, notifier_options)
+          notifier.notify
+        end
+
+        success
       end
 
       private
@@ -226,6 +249,48 @@ module GroongaQueryLog
           @read_timeout = timeout
         end
 
+        parser.separator("")
+        parser.separator("Notifications:")
+        parser.on("--smtp-server=SERVER",
+                  "Use SERVER as SMTP server",
+                  "(#{@smtp_server})") do |server|
+          @smtp_server = server
+        end
+        parser.on("--smtp-auth-user=USER",
+                  "Use USER for SMTP AUTH",
+                  "(#{@smtp_auth_user})") do |user|
+          @smtp_auth_user = user
+        end
+        parser.on("--smtp-auth-password=PASSWORD",
+                  "Use PASSWORD for SMTP AUTH",
+                  "(#{@smtp_auth_password})") do |password|
+          @smtp_auth_password = password
+        end
+        parser.on("--[no-]smtp-starttls",
+                  "Whether use StartTLS in SMTP or not",
+                  "(#{@smtp_starttls})") do |boolean|
+          @smtp_starttls = boolean
+        end
+        parser.on("--smtp-port=PORT", Integer,
+                  "Use PORT as SMTP server port",
+                  "(#{@smtp_port})") do |port|
+          @smtp_port = port
+        end
+        parser.on("--mail-to=TO",
+                  "Send a notification e-mail to TO",
+                  "(#{@mail_to})") do |to|
+          @mail_to = to
+        end
+        parser.on("--mail-subject-on-success=SUBJECT",
+                  "Use SUBJECT as subject for notification e-mail on success",
+                  "(#{@mail_subject_on_success})") do |subject|
+          @mail_subject_on_success = subject
+        end
+        parser.on("--mail-subject-on-failure=SUBJECT",
+                  "Use SUBJECT as subject for notification e-mail on failure",
+                  "(#{@mail_subject_on_failure})") do |subject|
+          @mail_subject_on_failure = subject
+        end
         parser
       end
 
@@ -267,6 +332,20 @@ module GroongaQueryLog
           :read_timeout => @read_timeout,
         }
         directory_options.merge(options)
+      end
+
+      def notifier_options
+        options = {
+          :smtp_server => @smtp_server,
+          :smtp_auth_user => @smtp_auth_user,
+          :smtp_auth_password => @smtp_auth_password,
+          :smtp_port => @smtp_port,
+          :smtp_starttls => @smtp_starttls,
+          :mail_subject_on_failure => @mail_subject_on_failure,
+          :mail_subject_on_success => @mail_subject_on_success,
+          :mail_from => @mail_from,
+          :mail_to => @mail_to
+        }
       end
 
       def old_groonga_server
@@ -583,6 +662,79 @@ module GroongaQueryLog
 
         def use_persistent_cache?
           @old.use_persistent_cache? or @new.use_persistent_cache?
+        end
+      end
+
+      class MailNotifier
+
+        def initialize(success, elapsed_time, options)
+          @success = success
+          @elapsed_time = elapsed_time
+          @options = options
+        end
+
+        def notify
+          format_log = ""
+          Tempfile.open("format_stdout") do |output|
+            options = {:output => output}
+            command = GroongaQueryLog::Command::FormatRegressionTestLogs.new(options)
+            command.run(["results"])
+            output.rewind
+            format_log = output.read
+          end
+
+          subject = @options[:mail_subject_on_success]
+          content = format_elapsed_time
+          if @tester_result
+            content << "Done."
+          else
+            subject = @options[:mail_subject_on_failure]
+            content << "Report:"
+            content << format_log
+          end
+          send_mail(subject, content)
+        end
+
+        private
+        def format_elapsed_time
+          elapsed_seconds = @elapsed_time % 60
+          elapsed_minutes = @elapsed_time / 60 % 60
+          elapsed_hours = @elapsed_time / 60 / 60 % 24
+          elapsed_days = @elapsed_time / 60 / 60 / 24
+          "Elapsed: %ddays %02d:%02d:%02d\n" % [
+            elapsed_days,
+            elapsed_hours,
+            elapsed_minutes,
+            elapsed_seconds
+          ]
+        end
+
+        def send_mail(subject, content)
+          header = <<-HEADER
+X-Mailer: groonga-query-log test reporter
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: base64
+From: #{@options[:mail_from]}
+To: #{@options[:mail_to]}
+Subject: #{subject}
+Date: #{Time.now.rfc2822}
+          HEADER
+
+          body = Base64.encode64(content)
+
+          mail = <<-MAIL.gsub(/\r?\n/, "\r\n")
+#{header}
+
+#{body}
+          MAIL
+          smtp = Net::SMTP.new(@options[:smtp_server], @options[:smtp_port])
+          smtp.enable_starttls if @options[:smtp_starttls]
+          smtp.start(@options[:smtp_server],
+                     @options[:smtp_auth_user],
+                     @options[:smtp_auth_password]) do
+            smtp.send_message(mail, @options[:mail_from], @options[:mail_to])
+          end
         end
       end
     end

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -669,6 +669,7 @@ module GroongaQueryLog
           @success = success
           @elapsed_time = elapsed_time
           @options = options
+          @path = @options[:path] || "results"
         end
 
         def notify

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -672,15 +672,13 @@ module GroongaQueryLog
           @path = @options[:path] || "results"
         end
 
-        def notify
+        def notify(output=nil)
           format_log = ""
-          Tempfile.open("format_stdout") do |output|
-            options = {:output => output}
-            command = GroongaQueryLog::Command::FormatRegressionTestLogs.new(options)
-            command.run(["results"])
-            output.rewind
-            format_log = output.read
-          end
+          @output = output || StringIO.new
+          options = {:output => @output}
+          command = GroongaQueryLog::Command::FormatRegressionTestLogs.new(options)
+          command.run([@path])
+          format_log = @output.string
 
           subject = @options[:mail_subject_on_success]
           content = format_elapsed_time

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -334,7 +334,7 @@ module GroongaQueryLog
       end
 
       def notifier_options
-        options = {
+        {
           :smtp_server => @smtp_server,
           :smtp_auth_user => @smtp_auth_user,
           :smtp_auth_password => @smtp_auth_password,

--- a/test/command/test-run-regression-test.rb
+++ b/test/command/test-run-regression-test.rb
@@ -1,0 +1,57 @@
+# coding: utf-8
+# Copyright (C) 2019 Kentaro Hayashi <hayashi@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "groonga-query-log/command/run-regression-test"
+
+class RunRegressionTestCommandTest < Test::Unit::TestCase
+  include Helper::Path
+
+  def fixture_path(*components)
+    super("regression-test-logs", *components)
+  end
+
+  sub_test_case(".new") do
+    def test_notifier
+      options = {
+        :mail_to => "noreply@#{Socket.gethostname}",
+        :path => fixture_path("url-format.log"),
+        :skip_smtp => true
+      }
+      notifier = GroongaQueryLog::Command::RunRegressionTest::MailNotifier.new(true, 3000, options)
+      output = StringIO.new
+      notifier.notify(output)
+      expected = <<-OUTPUT
+Command:
+/d/select?table=Logs&match_columns=message&query=%E7%84%BC%E8%82%89
+Name: select
+Arguments:
+  match_columns: message
+  query: 焼肉
+  table: Logs
+--- old
++++ new
+@@ -1,4 +1,4 @@
+ [[[2],
+   [["_id", "UInt32"], ["message", "Text"]],
+   [1, "log message1: 焼肉"],
+-  [2, "log message2: 焼肉"]]]
++  [3, "log message3: 焼肉"]]]
+      OUTPUT
+      assert_equal(expected, output.string)
+    end
+  end
+end


### PR DESCRIPTION
There is a case that groonga-query-log is invoked from shell script and it needs to report test result
as a use-case.
If groonga-query-log supports such notification feature by default, it makes more usable. (it also works easily on windows)
