### PR TITLE
run-regression-test: support rewriting "column1 @ \"keyword\" && column2 @~ \"^(?!.*keyword1|keyword2|...).+$\""

### DIFF
--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -188,7 +188,7 @@ module GroongaQueryLog
                   "specifying this option multiple times") do |accessor|
           @nullable_reference_number_accessors << accessor
         end
-        parser.on("--[no-]rewrite_regular_expression",
+        parser.on("--[no-]rewrite-regular-expression",
                   "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -189,10 +189,10 @@ module GroongaQueryLog
           @nullable_reference_number_accessors << accessor
         end
         parser.on("--[no-]rewrite_regular_expression",
-                  "Rewrite 'column1 @ \"keyword\" && column2 @~ " +
-                  "\"^(?!.*keyword1|keyword2|...).+$\"' " +
-                  "with 'column1 @ \"keyword\" &! column2 @ \"keyword1\" " +
-                  "&! column2 @ \"keyword2\" &! ...'",
+                  "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
+                  "\"^(?!.*keyword2|keyword3|...).+$\"' " +
+                  "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +
+                  "&! column2 @ \"keyword3\" &! ...'",
                   "(#{@rewrite_regular_expression})") do |boolean|
           @rewrite_regular_expression = boolean
         end

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -50,6 +50,7 @@ module GroongaQueryLog
         @vector_accessors = []
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
+        @rewrite_regular_expression = false
 
         @care_order = true
         @ignored_drilldown_keys = []
@@ -187,6 +188,14 @@ module GroongaQueryLog
                   "specifying this option multiple times") do |accessor|
           @nullable_reference_number_accessors << accessor
         end
+        parser.on("--[no-]rewrite_regular_expression",
+                  "Rewrite 'column1 @ \"keyword\" && column2 @~ " +
+                  "\"^(?!.*keyword1|keyword2|...).+$\"' " +
+                  "with 'column1 @ \"keyword\" &! column2 @ \"keyword1\" " +
+                  "&! column2 @ \"keyword2\" &! ...'",
+                  "(#{@rewrite_regular_expression})") do |boolean|
+          @rewrite_regular_expression = boolean
+        end
 
         parser.separator("")
         parser.separator("Comparisons:")
@@ -252,6 +261,8 @@ module GroongaQueryLog
             @rewrite_nullable_reference_number,
           :nullable_reference_number_accessors =>
             @nullable_reference_number_accessors,
+          :rewrite_regular_expression =>
+            @rewrite_regular_expression,
           :target_command_names => @target_command_names,
           :read_timeout => @read_timeout,
         }
@@ -546,6 +557,9 @@ module GroongaQueryLog
           accessors.each do |accessor|
             command_line << "--nullable-reference-number-accessor"
             command_line << accessor
+          end
+          if @options[:rewrite_regular_expression]
+            command_line << "--rewrite_regular_expression"
           end
           if @options[:target_command_names]
             command_line << "--target-command-names"

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -50,7 +50,7 @@ module GroongaQueryLog
         @vector_accessors = []
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
-        @rewrite_regular_expression = false
+        @rewrite_not_or_regular_expression = false
 
         @care_order = true
         @ignored_drilldown_keys = []
@@ -193,8 +193,8 @@ module GroongaQueryLog
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +
                   "&! column2 @ \"keyword3\" &! ...'",
-                  "(#{@rewrite_regular_expression})") do |boolean|
-          @rewrite_regular_expression = boolean
+                  "(#{@rewrite_not_or_regular_expression})") do |boolean|
+          @rewrite_not_or_regular_expression = boolean
         end
 
         parser.separator("")
@@ -261,8 +261,8 @@ module GroongaQueryLog
             @rewrite_nullable_reference_number,
           :nullable_reference_number_accessors =>
             @nullable_reference_number_accessors,
-          :rewrite_regular_expression =>
-            @rewrite_regular_expression,
+          :rewrite_not_or_regular_expression =>
+            @rewrite_not_or_regular_expression,
           :target_command_names => @target_command_names,
           :read_timeout => @read_timeout,
         }
@@ -558,8 +558,8 @@ module GroongaQueryLog
             command_line << "--nullable-reference-number-accessor"
             command_line << accessor
           end
-          if @options[:rewrite_regular_expression]
-            command_line << "--rewrite_regular_expression"
+          if @options[:rewrite_not_or_regular_expression]
+            command_line << "--rewrite-not-or-regular-expression"
           end
           if @options[:target_command_names]
             command_line << "--target-command-names"

--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -188,7 +188,7 @@ module GroongaQueryLog
                   "specifying this option multiple times") do |accessor|
           @nullable_reference_number_accessors << accessor
         end
-        parser.on("--[no-]rewrite-regular-expression",
+        parser.on("--[no-]rewrite-not-or-regular-expression",
                   "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -235,8 +235,8 @@ module GroongaQueryLog
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +
                   "&! column2 @ \"keyword3\" &! ...'",
-                  "(#{@options.rewrite_regular_expression?})") do |boolean|
-          @options.rewrite_regular_expression = boolean
+                  "(#{@options.rewrite_not_or_regular_expression?})") do |boolean|
+          @options.rewrite_not_or_regular_expression = boolean
         end
 
         parser.on("--nullable-reference-number-accessor=ACCESSOR",

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -231,10 +231,10 @@ module GroongaQueryLog
         end
 
         parser.on("--[no-]rewrite_regular_expression",
-                  "Rewrite 'column1 @ \"keyword\" && column2 @~ " +
-                  "\"^(?!.*keyword1|keyword2|...).+$\"' " +
-                  "with 'column1 @ \"keyword\" &! column2 @ \"keyword1\" " +
-                  "&! column2 @ \"keyword2\" &! ...'",
+                  "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
+                  "\"^(?!.*keyword2|keyword3|...).+$\"' " +
+                  "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +
+                  "&! column2 @ \"keyword3\" &! ...'",
                   "(#{@options.rewrite_regular_expression?})") do |boolean|
           @options.rewrite_regular_expression = boolean
         end

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -230,7 +230,7 @@ module GroongaQueryLog
           @options.rewrite_nullable_reference_number = boolean
         end
 
-        parser.on("--[no-]rewrite_regular_expression",
+        parser.on("--[no-]rewrite-regular-expression",
                   "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -230,7 +230,7 @@ module GroongaQueryLog
           @options.rewrite_nullable_reference_number = boolean
         end
 
-        parser.on("--[no-]rewrite-regular-expression",
+        parser.on("--[no-]rewrite-not-or-regular-expression",
                   "Rewrite 'column1 @ \"keyword1\" && column2 @~ " +
                   "\"^(?!.*keyword2|keyword3|...).+$\"' " +
                   "with 'column1 @ \"keyword1\" &! column2 @ \"keyword2\" " +

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -230,6 +230,15 @@ module GroongaQueryLog
           @options.rewrite_nullable_reference_number = boolean
         end
 
+        parser.on("--[no-]rewrite_regular_expression",
+                  "Rewrite 'column1 @ \"keyword\" && column2 @~ " +
+                  "\"^(?!.*keyword1|keyword2|...).+$\"' " +
+                  "with 'column1 @ \"keyword\" &! column2 @ \"keyword1\" " +
+                  "&! column2 @ \"keyword2\" &! ...'",
+                  "(#{@options.rewrite_regular_expression?})") do |boolean|
+          @options.rewrite_regular_expression = boolean
+        end
+
         parser.on("--nullable-reference-number-accessor=ACCESSOR",
                   "Mark ACCESSOR as rewrite nullable reference number targets",
                   "You can specify multiple accessors by",

--- a/lib/groonga-query-log/filter-rewriter.rb
+++ b/lib/groonga-query-log/filter-rewriter.rb
@@ -35,8 +35,8 @@ module GroongaQueryLog
       if @options[:rewrite_nullable_reference_number]
         rewritten = rewrite_nullable_reference_number(rewritten)
       end
-      if @options[:rewrite_regular_expression]
-        rewritten = rewrite_regular_expression(rewritten)
+      if @options[:rewrite_not_or_regular_expression]
+        rewritten = rewrite_not_or_regular_expression(rewritten)
       end
       rewritten
     end
@@ -81,7 +81,7 @@ module GroongaQueryLog
       end
     end
 
-    def rewrite_regular_expression(filter)
+    def rewrite_not_or_regular_expression(filter)
       filter.gsub(/&& *(?<target_column>[a-zA-Z0-9_.]+) *@~ *"(?<pattern>.*?)"/) do |matched|
         target_column = $LAST_MATCH_INFO[:target_column]
         pattern = $LAST_MATCH_INFO[:pattern]

--- a/lib/groonga-query-log/filter-rewriter.rb
+++ b/lib/groonga-query-log/filter-rewriter.rb
@@ -90,9 +90,7 @@ module GroongaQueryLog
         when /\A(?<header>(?:\^|\\A)\(\?\!\.\*)
                 (?<body>.+)
                 (?<footer>\)\.[+*](?:\$|\\z))\z/x
-          header = $LAST_MATCH_INFO[:header]
           body = $LAST_MATCH_INFO[:body]
-          footer = $LAST_MATCH_INFO[:footer]
           conditions = body.split("|").collect do |word|
             "&! #{target_column} @ \"#{word.strip}\""
           end

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -240,6 +240,7 @@ module GroongaQueryLog
       attr_accessor :vector_accessors
       attr_writer :rewrite_nullable_reference_number
       attr_accessor :nullable_reference_number_accessors
+      attr_writer :rewrite_regular_expression
       def initialize
         @groonga1 = GroongaOptions.new
         @groonga2 = GroongaOptions.new
@@ -268,6 +269,7 @@ module GroongaQueryLog
         @vector_accessors = []
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
+        @rewrite_regular_expression = false
       end
 
       def request_queue_size
@@ -298,6 +300,10 @@ module GroongaQueryLog
         @rewrite_nullable_reference_number
       end
 
+      def rewrite_regular_expression?
+        @rewrite_regular_expression
+      end
+
       def target_command_name?(name)
         return false if name.nil?
 
@@ -326,7 +332,8 @@ module GroongaQueryLog
       def need_filter_rewrite?
         rewrite_vector_equal? or
           rewrite_vector_not_equal_empty_string? or
-          rewrite_nullable_reference_number?
+          rewrite_nullable_reference_number? or
+          rewrite_regular_expression
       end
 
       def to_filter_rewriter_options
@@ -339,6 +346,8 @@ module GroongaQueryLog
             rewrite_nullable_reference_number?,
           :nullable_reference_number_accessors =>
             nullable_reference_number_accessors,
+          :rewrite_regular_expression =>
+            rewrite_regular_expression?,
         }
       end
     end

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -240,7 +240,7 @@ module GroongaQueryLog
       attr_accessor :vector_accessors
       attr_writer :rewrite_nullable_reference_number
       attr_accessor :nullable_reference_number_accessors
-      attr_writer :rewrite_regular_expression
+      attr_writer :rewrite_not_or_regular_expression
       def initialize
         @groonga1 = GroongaOptions.new
         @groonga2 = GroongaOptions.new
@@ -269,7 +269,7 @@ module GroongaQueryLog
         @vector_accessors = []
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
-        @rewrite_regular_expression = false
+        @rewrite_not_or_regular_expression = false
       end
 
       def request_queue_size
@@ -300,8 +300,8 @@ module GroongaQueryLog
         @rewrite_nullable_reference_number
       end
 
-      def rewrite_regular_expression?
-        @rewrite_regular_expression
+      def rewrite_not_or_regular_expression?
+        @rewrite_not_or_regular_expression
       end
 
       def target_command_name?(name)
@@ -333,7 +333,7 @@ module GroongaQueryLog
         rewrite_vector_equal? or
           rewrite_vector_not_equal_empty_string? or
           rewrite_nullable_reference_number? or
-          rewrite_regular_expression
+          rewrite_not_or_regular_expression
       end
 
       def to_filter_rewriter_options
@@ -346,8 +346,8 @@ module GroongaQueryLog
             rewrite_nullable_reference_number?,
           :nullable_reference_number_accessors =>
             nullable_reference_number_accessors,
-          :rewrite_regular_expression =>
-            rewrite_regular_expression?,
+          :rewrite_not_or_regular_expression =>
+            rewrite_not_or_regular_expression?,
         }
       end
     end

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -127,6 +127,11 @@ class FilterRewriterTest < Test::Unit::TestCase
                    rewrite("column1 @ \"value1\" && reference.column2 @~ \"^(?!.*value2).+$\""))
     end
 
+    def test_under_score
+      assert_equal("column1 @ \"value1\" &! column_2 @ \"value_2\"",
+                   rewrite("column1 @ \"value1\" && column_2 @~ \"^(?!.*value_2).+$\""))
+    end
+
     def test_rewrite_multiple
       assert_equal("column1 @ \"value1\" &! column2 @ \"value2\" &! column2 @ \"value3\" &! column2 @ \"value4\"",
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2 | value3 | value4).+$\""))

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -122,11 +122,6 @@ class FilterRewriterTest < Test::Unit::TestCase
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\""))
     end
 
-    def test_no_rewrite
-      assert_equal("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\"",
-                   rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\"", false))
-    end
-
     def test_rewrite_multiple
       assert_equal("column1 @ \"value1\" &! column2 @ \"value2\" &! column2 @ \"value3\" &! column2 @ \"value4\"",
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2 | value3 | value4).+$\""))

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -114,7 +114,7 @@ class FilterRewriterTest < Test::Unit::TestCase
   class RegularExpressionTest < self
     def rewrite(filter, enabled = true)
       super(filter,
-            :rewrite_regular_expression => enabled)
+            :rewrite_not_or_regular_expression => enabled)
     end
 
     def test_rewrite_one

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -122,6 +122,11 @@ class FilterRewriterTest < Test::Unit::TestCase
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\""))
     end
 
+    def test_reference
+      assert_equal("column1 @ \"value1\" &! reference.column2 @ \"value2\"",
+                   rewrite("column1 @ \"value1\" && reference.column2 @~ \"^(?!.*value2).+$\""))
+    end
+
     def test_rewrite_multiple
       assert_equal("column1 @ \"value1\" &! column2 @ \"value2\" &! column2 @ \"value3\" &! column2 @ \"value4\"",
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2 | value3 | value4).+$\""))

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -112,14 +112,19 @@ class FilterRewriterTest < Test::Unit::TestCase
   end
 
   class RegularExpressionTest < self
-    def rewrite(filter)
+    def rewrite(filter, enabled = true)
       super(filter,
-            :rewrite_regular_expression => true)
+            :rewrite_regular_expression => enabled)
     end
 
     def test_rewrite_one
       assert_equal("column1 @ \"value1\" &! column2 @ \"value2\"",
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\""))
+    end
+
+    def test_no_rewrite
+      assert_equal("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\"",
+                   rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\"", false))
     end
 
     def test_rewrite_multiple

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -110,4 +110,21 @@ class FilterRewriterTest < Test::Unit::TestCase
                            ["ref_column.number"]))
     end
   end
+
+  class RegularExpressionTest < self
+    def rewrite(filter)
+      super(filter,
+            :rewrite_regular_expression => true)
+    end
+
+    def test_rewrite_one
+      assert_equal("column1 @ \"value1\" &! column2 @ \"value2\"",
+                   rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2).+$\""))
+    end
+
+    def test_rewrite_multiple
+      assert_equal("column1 @ \"value1\" &! column2 @ \"value2\" &! column2 @ \"value3\" &! column2 @ \"value4\"",
+                   rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2 | value3 | value4).+$\""))
+    end
+  end
 end


### PR DESCRIPTION
This feature that for backward compatibility.

A new Groonga( version 5.0.7 or later) normalizes match target text by NormalizerAuto normalizer when Groonga doesn’t use an index for regular expression search.

Therefore, there is a possibility to a different result of regular expression search between an old Groonga and a new Groonga.

This feature replaces a complex regular expression that cannot use the index to doesn't use a regular expression.