### PR TITLE
Fix unexpected NoMethodError

### DIFF
--- a/lib/groonga-query-log/statistic.rb
+++ b/lib/groonga-query-log/statistic.rb
@@ -121,14 +121,17 @@ module GroongaQueryLog
         "return_code" => return_code,
         "slow" => slow?,
       }
-      arguments = command.arguments.collect do |key, value|
-        {"key" => key, "value" => value}
+      if command
+        data["command"] = {
+          "raw" => raw_command,
+          "name" => command.name,
+          "parameters" => command_arguments,
+        }
+      else
+        data["command"] = {
+          "raw" => raw_command
+        }
       end
-      data["command"] = {
-        "raw" => raw_command,
-        "name" => command.name,
-        "parameters" => arguments,
-      }
       operations = []
       each_operation do |operation|
         operation_data = {}
@@ -191,6 +194,13 @@ module GroongaQueryLog
 
     def slow_operation?(elapsed)
       elapsed >= @slow_operation_threshold
+    end
+
+    def command_arguments
+      arguments = command.arguments.collect do |key, value|
+        {"key" => key, "value" => value}
+      end
+      arguments
     end
   end
 end

--- a/lib/groonga-query-log/statistic.rb
+++ b/lib/groonga-query-log/statistic.rb
@@ -197,10 +197,9 @@ module GroongaQueryLog
     end
 
     def command_arguments
-      arguments = command.arguments.collect do |key, value|
+      command.arguments.collect do |key, value|
         {"key" => key, "value" => value}
       end
-      arguments
     end
   end
 end

--- a/test/test-parser.rb
+++ b/test/test-parser.rb
@@ -43,6 +43,17 @@ class ParserTest < Test::Unit::TestCase
     assert_equal([nil], statistics.collect(&:command))
   end
 
+  def test_no_command_to_hash
+    statistics = parse(<<-LOG)
+2012-12-13 11:15:20.628105|0x7fff148c8a50|>/
+2012-12-13 11:15:21.645119|0x7fff148c8a50|<000000017041150 rc=0
+    LOG
+    expected = {
+      "raw" => "/"
+    }
+    assert_equal(expected, statistics[0].to_hash["command"])
+  end
+
   private
   def parse(log)
     statistics = []


### PR DESCRIPTION
When access to document root "/" is recorded, command is set to
nil. It causes the following error when calling command.arguments in
 #to_hash method because to_hash doesn't care command==nil case.

  NoMethodError: undefined method `arguments' for nil:NilClass