### PR TITLE
run-regression-test: add a new rewrite filter for rewriting "&& !" operator

### DIFF
--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -55,6 +55,7 @@ module GroongaQueryLog
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
         @rewrite_not_or_regular_expression = false
+        @rewrite_and_not_operator = false
 
         @care_order = true
         @ignored_drilldown_keys = []
@@ -220,6 +221,14 @@ module GroongaQueryLog
                   "(#{@rewrite_not_or_regular_expression})") do |boolean|
           @rewrite_not_or_regular_expression = boolean
         end
+        parser.on("--[no-]rewrite-and-not-operator",
+                  "Rewrite '(column1 @ \"keyword1\") && !(column2 @ " +
+                  "\"keyword2\")' " +
+                  "with '(column1 @ \"keyword1\") &! (column2 @ " +
+                  "\"keyword2\")'",
+                  "(#{@rewrite_and_not_operator})") do |boolean|
+          @rewrite_and_not_operator = boolean
+        end
 
         parser.separator("")
         parser.separator("Comparisons:")
@@ -329,6 +338,8 @@ module GroongaQueryLog
             @nullable_reference_number_accessors,
           :rewrite_not_or_regular_expression =>
             @rewrite_not_or_regular_expression,
+          :rewite_and_not_operator =>
+            @rewrite_and_not_operator,
           :target_command_names => @target_command_names,
           :read_timeout => @read_timeout,
         }
@@ -626,6 +637,9 @@ module GroongaQueryLog
           end
           if @options[:rewrite_not_or_regular_expression]
             command_line << "--rewrite-not-or-regular-expression"
+          end
+          if @options[:rewrite_and_not_operator]
+            command_line << "--rewrite-and-not-operator"
           end
           if @options[:target_command_names]
             command_line << "--target-command-names"

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -239,6 +239,15 @@ module GroongaQueryLog
           @options.rewrite_not_or_regular_expression = boolean
         end
 
+        parser.on("--[no-]rewrite-and-not-operator",
+                  "Rewrite '(column1 @ \"keyword1\") && !(column2 @ " +
+                  "\"keyword2\")' " +
+                  "with '(column1 @ \"keyword1\") &! (column2 @ " +
+                  "\"keyword2\")'",
+                  "(#{@options.rewrite_and_not_operator?})") do |boolean|
+          @options.rewrite_and_not_operator = boolean
+        end
+
         parser.on("--nullable-reference-number-accessor=ACCESSOR",
                   "Mark ACCESSOR as rewrite nullable reference number targets",
                   "You can specify multiple accessors by",

--- a/lib/groonga-query-log/filter-rewriter.rb
+++ b/lib/groonga-query-log/filter-rewriter.rb
@@ -38,6 +38,9 @@ module GroongaQueryLog
       if @options[:rewrite_not_or_regular_expression]
         rewritten = rewrite_not_or_regular_expression(rewritten)
       end
+      if @options[:rewrite_and_not_operator]
+        rewritten = rewrite_and_not_operator(rewritten)
+      end
       rewritten
     end
 
@@ -99,6 +102,10 @@ module GroongaQueryLog
           matched
         end
       end
+    end
+
+    def rewrite_and_not_operator(filter)
+      filter.gsub(/&& *!/, "&!")
     end
   end
 end

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -241,6 +241,7 @@ module GroongaQueryLog
       attr_writer :rewrite_nullable_reference_number
       attr_accessor :nullable_reference_number_accessors
       attr_writer :rewrite_not_or_regular_expression
+      attr_writer :rewrite_and_not_operator
       def initialize
         @groonga1 = GroongaOptions.new
         @groonga2 = GroongaOptions.new
@@ -270,6 +271,7 @@ module GroongaQueryLog
         @rewrite_nullable_reference_number = false
         @nullable_reference_number_accessors = []
         @rewrite_not_or_regular_expression = false
+        @rewrite_and_not_operator = false
       end
 
       def request_queue_size
@@ -304,6 +306,10 @@ module GroongaQueryLog
         @rewrite_not_or_regular_expression
       end
 
+      def rewrite_and_not_operator?
+        @rewrite_and_not_operator
+      end
+
       def target_command_name?(name)
         return false if name.nil?
 
@@ -333,7 +339,8 @@ module GroongaQueryLog
         rewrite_vector_equal? or
           rewrite_vector_not_equal_empty_string? or
           rewrite_nullable_reference_number? or
-          rewrite_not_or_regular_expression?
+          rewrite_not_or_regular_expression? or
+          rewrite_and_not_operator?
       end
 
       def to_filter_rewriter_options
@@ -348,6 +355,8 @@ module GroongaQueryLog
             nullable_reference_number_accessors,
           :rewrite_not_or_regular_expression =>
             rewrite_not_or_regular_expression?,
+          :rewrite_and_not_operator =>
+            rewrite_and_not_operator?,
         }
       end
     end

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -149,16 +149,6 @@ class FilterRewriterTest < Test::Unit::TestCase
                    rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\")"))
     end
 
-    def test_reference
-      assert_equal("(column1 @ \"value1\") &! (reference.column2 @ \"value2\")",
-                   rewrite("(column1 @ \"value1\") && ! (reference.column2 @ \"value2\")"))
-    end
-
-    def test_under_score
-      assert_equal("(column1 @ \"value1\") &! (column_2 @ \"value2\")",
-                   rewrite("(column1 @ \"value1\") && ! (column_2 @ \"value2\")"))
-    end
-
     def test_rewrite_multiple
       assert_equal("(column1 @ \"value1\") &! (column2 @ \"value2\") &! (column2 @ \"value3\")",
                    rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\") && ! (column2 @ \"value3\")"))

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -144,12 +144,12 @@ class FilterRewriterTest < Test::Unit::TestCase
             :rewrite_and_not_operator => enabled)
     end
 
-    def test_rewrite_one
+    def test_one
       assert_equal("(column1 @ \"value1\") &! (column2 @ \"value2\")",
                    rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\")"))
     end
 
-    def test_rewrite_multiple
+    def test_multiple
       assert_equal("(column1 @ \"value1\") &! (column2 @ \"value2\") &! (column2 @ \"value3\")",
                    rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\") && ! (column2 @ \"value3\")"))
     end

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -137,4 +137,31 @@ class FilterRewriterTest < Test::Unit::TestCase
                    rewrite("column1 @ \"value1\" && column2 @~ \"^(?!.*value2 | value3 | value4).+$\""))
     end
   end
+
+  class AndNotOperatorTest < self
+    def rewrite(filter, enabled = true)
+      super(filter,
+            :rewrite_and_not_operator => enabled)
+    end
+
+    def test_rewrite_one
+      assert_equal("(column1 @ \"value1\") &! (column2 @ \"value2\")",
+                   rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\")"))
+    end
+
+    def test_reference
+      assert_equal("(column1 @ \"value1\") &! (reference.column2 @ \"value2\")",
+                   rewrite("(column1 @ \"value1\") && ! (reference.column2 @ \"value2\")"))
+    end
+
+    def test_under_score
+      assert_equal("(column1 @ \"value1\") &! (column_2 @ \"value2\")",
+                   rewrite("(column1 @ \"value1\") && ! (column_2 @ \"value2\")"))
+    end
+
+    def test_rewrite_multiple
+      assert_equal("(column1 @ \"value1\") &! (column2 @ \"value2\") &! (column2 @ \"value3\")",
+                   rewrite("(column1 @ \"value1\") && ! (column2 @ \"value2\") && ! (column2 @ \"value3\")"))
+    end
+  end
 end


### PR DESCRIPTION
This feature that for backward compatibility.

A new Groonga rewrite `&& !` to `&!` automatically for using index.
An old Groonga does not rewrite that.

Therefore, there is a possibility to a different result of calculating a score between an old Groonga and a new Groonga.