### PR TITLE
Fix a rewrite value

### DIFF
--- a/lib/groonga-query-log/filter-rewriter.rb
+++ b/lib/groonga-query-log/filter-rewriter.rb
@@ -1,4 +1,5 @@
 # Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2019  Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -77,7 +78,7 @@ module GroongaQueryLog
         accessor = $1
         if @nullable_reference_number_accessors.include?(accessor)
           sub_accessor = accessor.split(".")[0..-2].join(".")
-          "(#{sub_accessor}._key == null ? 0 : #{accessor})"
+          "(#{sub_accessor}._key == \"\" ? 0 : #{accessor})"
         else
           matched
         end

--- a/test/test-filter-rewriter.rb
+++ b/test/test-filter-rewriter.rb
@@ -1,4 +1,5 @@
 # Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2019  Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -99,13 +100,13 @@ class FilterRewriterTest < Test::Unit::TestCase
     end
 
     def test_parenthesis
-      assert_equal("(((reference._key == null ? 0 : reference.number)) < 1000)",
+      assert_equal("(((reference._key == \"\" ? 0 : reference.number)) < 1000)",
                    rewrite("((reference.number) < 1000)",
                            ["reference.number"]))
     end
 
     def test_under_score
-      assert_equal("(ref_column._key == null ? 0 : ref_column.number) < 1000",
+      assert_equal("(ref_column._key == \"\" ? 0 : ref_column.number) < 1000",
                    rewrite("ref_column.number < 1000",
                            ["ref_column.number"]))
     end


### PR DESCRIPTION
We need a rewrite to false when reference is null.
Because new Groonga sets false if reference is null.