### PR TITLE
run-regression-test: use fastest elapsed time in comparison

### DIFF
--- a/lib/groonga-query-log/command/run-regression-test.rb
+++ b/lib/groonga-query-log/command/run-regression-test.rb
@@ -65,6 +65,7 @@ module GroongaQueryLog
         @target_command_names = ServerVerifier::Options.new.target_command_names
 
         @verify_performance = false
+        @performance_verfifier_options = PerformanceVerifier::Options.new
 
         @read_timeout = Groonga::Client::Default::READ_TIMEOUT
 
@@ -269,6 +270,17 @@ module GroongaQueryLog
                   "[#{@verify_performance}]") do |boolean|
           @verify_performance = boolean
         end
+        available_choose_strategies =
+          @performance_verfifier_options.available_choose_strategies
+        default_choose_strategy =
+          @performance_verfifier_options.choose_strategy
+        parser.on("--performance-choose-strategy=STRATEGY",
+                  available_choose_strategies,
+                  "How to choose elapsed time",
+                  "(#{available_choose_strategies.join(", ")})",
+                  "[#{default_choose_strategy}]") do |strategy|
+          @performance_verfifier_options.choose_strategy = strategy
+        end
 
         parser.separator("")
         parser.separator("Network:")
@@ -372,6 +384,7 @@ module GroongaQueryLog
             @rewrite_and_not_operator,
           :target_command_names => @target_command_names,
           :verify_performance => @verify_performance,
+          :performance_verfifier_options => @performance_verfifier_options,
           :read_timeout => @read_timeout,
         }
         directory_options.merge(options)
@@ -678,6 +691,9 @@ module GroongaQueryLog
           end
           if @options[:verify_performance]
             command_line << "--verify-performance"
+            command_line << "--performance-choose-strategy"
+            options = @options[:performance_verfifier_options]
+            command_line << options.choose_strategy.to_s
           end
           if @options[:read_timeout]
             command_line << "--read-timeout"

--- a/lib/groonga-query-log/command/verify-server.rb
+++ b/lib/groonga-query-log/command/verify-server.rb
@@ -255,11 +255,7 @@ module GroongaQueryLog
           @options.nullable_reference_number_accessors << accessor
         end
 
-        parser.on("--[no-]verify-performance",
-                  "Whether verify performance or not",
-                  "[#{@options.verify_performance?}]") do |boolean|
-          @options.verify_performance = boolean
-        end
+        create_parser_performance(parser)
 
         parser.separator("")
         parser.separator("Debug options:")
@@ -267,6 +263,26 @@ module GroongaQueryLog
         parser.on("--abort-on-exception",
                   "Abort on exception in threads") do
           Thread.abort_on_exception = true
+        end
+      end
+
+      def create_parser_performance(parser)
+        parser.separator("")
+        parser.separator("Performance options:")
+
+        parser.on("--[no-]verify-performance",
+                  "Whether verify performance or not",
+                  "[#{@options.verify_performance?}]") do |boolean|
+          @options.verify_performance = boolean
+        end
+
+        options = @options.performance_verifier_options
+        parser.on("--performance-choose-strategy=STRATEGY",
+                  options.available_choose_strategies,
+                  "How to choose elapsed time",
+                  "(#{options.available_choose_strategies.join(", ")})",
+                  "[#{options.choose_strategy}]") do |strategy|
+          options.choose_strategy = strategy
         end
       end
     end

--- a/lib/groonga-query-log/performance-verifier.rb
+++ b/lib/groonga-query-log/performance-verifier.rb
@@ -59,7 +59,7 @@ module GroongaQueryLog
       elapsed_times = responses.collect do |response|
         response.elapsed_time
       end
-      elapsed_times.sort[elapsed_times.size / 2]
+      elapsed_times.sort.first
     end
 
     def compute_diff_ratio

--- a/lib/groonga-query-log/server-verifier.rb
+++ b/lib/groonga-query-log/server-verifier.rb
@@ -192,7 +192,10 @@ module GroongaQueryLog
         responses1 << groonga1_client.execute(command)
         responses2 << groonga2_client.execute(command)
       end
-      verifier = PerformanceVerifier.new(command, responses1, responses2)
+      verifier = PerformanceVerifier.new(command,
+                                         responses1,
+                                         responses2,
+                                         @options.performance_verifier_options)
       if verifier.slow?
         @slow = true
         @events.push([:slow,
@@ -276,6 +279,7 @@ module GroongaQueryLog
       attr_writer :rewrite_not_or_regular_expression
       attr_writer :rewrite_and_not_operator
       attr_writer :verify_performance
+      attr_reader :performance_verifier_options
       def initialize
         @groonga1 = GroongaOptions.new
         @groonga2 = GroongaOptions.new
@@ -307,6 +311,7 @@ module GroongaQueryLog
         @rewrite_not_or_regular_expression = false
         @rewrite_and_not_operator = false
         @verify_performance = false
+        @performance_verifier_options = PerformanceVerifier::Options.new
       end
 
       def request_queue_size

--- a/test/test-performance-verifier.rb
+++ b/test/test-performance-verifier.rb
@@ -1,0 +1,40 @@
+# Copyright (C) 2019  Kentaro Hayashi <hayashi@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class PerformanceVerifierTest < Test::Unit::TestCase
+  def setup
+    @old_responses = []
+    [0.3, 0.2, 0.1].each do |elapsed_time|
+      header = [0, 0, elapsed_time]
+      @old_responses << Groonga::Client::Response::Base.new(nil, header, nil)
+    end
+    @new_responses = []
+    [0.9, 0.5, 0.7].each do |elapsed_time|
+      header = [0, 0, elapsed_time]
+      @new_responses << Groonga::Client::Response::Base.new(nil, header, nil)
+    end
+  end
+
+  def test_old_elapsed_time
+    verifier = GroongaQueryLog::PerformanceVerifier.new(nil, @old_responses, @new_responses)
+    assert_equal(0.1, verifier.old_elapsed_time)
+  end
+
+  def test_new_elapsed_time
+    verifier = GroongaQueryLog::PerformanceVerifier.new(nil, @old_responses, @new_responses)
+    assert_equal(0.5, verifier.new_elapsed_time)
+  end
+end

--- a/test/test-performance-verifier.rb
+++ b/test/test-performance-verifier.rb
@@ -27,13 +27,17 @@ class PerformanceVerifierTest < Test::Unit::TestCase
     end
   end
 
+  def build_verifier
+    GroongaQueryLog::PerformanceVerifier.new(nil,
+                                             @old_responses,
+                                             @new_responses)
+  end
+
   def test_old_elapsed_time
-    verifier = GroongaQueryLog::PerformanceVerifier.new(nil, @old_responses, @new_responses)
-    assert_equal(0.1, verifier.old_elapsed_time)
+    assert_equal(0.1, build_verifier.old_elapsed_time)
   end
 
   def test_new_elapsed_time
-    verifier = GroongaQueryLog::PerformanceVerifier.new(nil, @old_responses, @new_responses)
-    assert_equal(0.5, verifier.new_elapsed_time)
+    assert_equal(0.5, build_verifier.new_elapsed_time)
   end
 end

--- a/test/test-performance-verifier.rb
+++ b/test/test-performance-verifier.rb
@@ -16,15 +16,14 @@
 
 class PerformanceVerifierTest < Test::Unit::TestCase
   def setup
-    @old_responses = []
-    [0.3, 0.2, 0.1].each do |elapsed_time|
+    @old_responses = build_responses([0.3, 0.2, 0.1])
+    @new_responses = build_responses([0.9, 0.5, 0.7])
+  end
+
+  def build_responses(elapsed_times)
+    elapsed_times.collect do |elapsed_time|
       header = [0, 0, elapsed_time]
-      @old_responses << Groonga::Client::Response::Base.new(nil, header, nil)
-    end
-    @new_responses = []
-    [0.9, 0.5, 0.7].each do |elapsed_time|
-      header = [0, 0, elapsed_time]
-      @new_responses << Groonga::Client::Response::Base.new(nil, header, nil)
+      Groonga::Client::Response::Base.new(nil, header, nil)
     end
   end
 

--- a/test/test-performance-verifier.rb
+++ b/test/test-performance-verifier.rb
@@ -18,6 +18,7 @@ class PerformanceVerifierTest < Test::Unit::TestCase
   def setup
     @old_responses = build_responses([0.3, 0.2, 0.1])
     @new_responses = build_responses([0.9, 0.5, 0.7])
+    @options = GroongaQueryLog::PerformanceVerifier::Options.new
   end
 
   def build_responses(elapsed_times)
@@ -30,14 +31,34 @@ class PerformanceVerifierTest < Test::Unit::TestCase
   def build_verifier
     GroongaQueryLog::PerformanceVerifier.new(nil,
                                              @old_responses,
-                                             @new_responses)
+                                             @new_responses,
+                                             @options)
   end
 
-  def test_old_elapsed_time
-    assert_equal(0.1, build_verifier.old_elapsed_time)
-  end
+  sub_test_case(":choose_strategy") do
+    sub_test_case(":fastest") do
+      def test_old_elapsed_time
+        assert_equal(0.1, build_verifier.old_elapsed_time)
+      end
 
-  def test_new_elapsed_time
-    assert_equal(0.5, build_verifier.new_elapsed_time)
+      def test_new_elapsed_time
+        assert_equal(0.5, build_verifier.new_elapsed_time)
+      end
+    end
+
+    sub_test_case(":median") do
+      def setup
+        super
+        @options.choose_strategy = :median
+      end
+
+      def test_old_elapsed_time
+        assert_equal(0.2, build_verifier.old_elapsed_time)
+      end
+
+      def test_new_elapsed_time
+        assert_equal(0.7, build_verifier.new_elapsed_time)
+      end
+    end
   end
 end


### PR DESCRIPTION
In the previous versions, the value of median is used to check
performance regression, but there is a case that response time is a
bit slow in occasionally, in such a case, the value of median is not
proper.