### PR TITLE
gemspec: add a missing dependency gem

### DIFF
--- a/groonga-query-log.gemspec
+++ b/groonga-query-log.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("diff-lcs")
   spec.add_runtime_dependency("groonga-client", ">= 0.6.2")
   spec.add_runtime_dependency("groonga-log", ">= 0.1.2")
+  spec.add_runtime_dependency("numo-narray")
 
   spec.add_development_dependency("test-unit")
   spec.add_development_dependency("test-unit-rr")


### PR DESCRIPTION
Because `groonga-query-log-analyze` use `numo-narray`.