### PR TITLE
Add `net-smtp` for Ruby 3.1 or higher

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
+          - "3.2"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Groonga APT repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Groonga APT repository

--- a/groonga-query-log.gemspec
+++ b/groonga-query-log.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("charty")
   spec.add_runtime_dependency("diff-lcs")
+  spec.add_runtime_dependency("net-smtp")
   spec.add_runtime_dependency("groonga-client", ">= 0.6.2")
   spec.add_runtime_dependency("groonga-log", ">= 0.1.2")
 


### PR DESCRIPTION
I got the following error in Ruby 3.1.

```
ruby -v
ruby 3.1.4p223 (2023-03-30 revision 957bb7cb81) [x86_64-linux]
```

```
/app/lib/groonga-query-log/command/run-regression-test.rb:24:in `require': cannot load such file -- net/smtp (LoadError)
	from /app/lib/groonga-query-log/command/run-regression-test.rb:24:in `<top (required)>'
	from bin/groonga-query-log-run-regression-test:20:in `require'
	from bin/groonga-query-log-run-regression-test:20:in `<main>'
```