### PR TITLE
Fix error in Groonga::Client.open

### DIFF
--- a/lib/groonga-query-log/replayer.rb
+++ b/lib/groonga-query-log/replayer.rb
@@ -193,11 +193,13 @@ module GroongaQueryLog
       end
 
       def create_client(&block)
-        Groonga::Client.open(:host     => @host,
-                             :port     => @port,
-                             :protocol => @protocol,
-                             :read_timeout => @read_timeout,
-                             &block)
+        options = {
+          :host => @host,
+          :port => @port,
+          :protocol => @protocol,
+          :read_timeout => @read_timeout
+        }
+        Groonga::Client.open(options, &block)
       end
 
       def create_request_output(&block)


### PR DESCRIPTION
Error messages output by the test.

```
  On subject Groonga::Client,
  unexpected method invocation:
    open(host: "127.0.0.1", port: 2929, protocol: :http, read_timeout: 60)
  expected invocations:
  - open({:host=>"127.0.0.1", :port=>2929, :protocol=>:http, :read_timeout=>60})
```