### PR TITLE
test: Fix the passing of arguments

### DIFF
--- a/test/test-replayer.rb
+++ b/test/test-replayer.rb
@@ -51,7 +51,7 @@ class ReplayerTest < Test::Unit::TestCase
           :read_timeout => 60,
         }
         expected_open_options = default_options.merge(expected_options)
-        mock(Groonga::Client).open(expected_open_options).yields(client) do
+        mock(Groonga::Client).open(**expected_open_options).yields(client) do
           client
         end
       end


### PR DESCRIPTION
```
  On subject Groonga::Client,
  unexpected method invocation:
    open(host: "127.0.0.1", port: 2929, protocol: :http, read_timeout: 60)
  expected invocations:
  - open({:host=>"127.0.0.1", :port=>2929, :protocol=>:http, :read_timeout=>60})
```