### PR TITLE
check-crash: Show PID and thread ID

### DIFF
--- a/lib/groonga-query-log/command/check-crash.rb
+++ b/lib/groonga-query-log/command/check-crash.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+# Copyright (C) 2018-2025  Sutou Kouhei <kou@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -160,6 +160,8 @@ module GroongaQueryLog
               puts("Important entries:")
               process.important_entries.each_with_index do |entry, i|
                 puts("#{entry.timestamp.iso8601}: " +
+                     "#{entry.pid}: " +
+                     "#{entry.thread_id}: " +
                      "#{entry.log_level}: " +
                      "#{entry.message}")
               end


### PR DESCRIPTION
They are useful to distinguish logs.