### PR TITLE
show-running-queries: fix running query condition

### DIFF
--- a/lib/groonga-query-log/command/show-running-queries.rb
+++ b/lib/groonga-query-log/command/show-running-queries.rb
@@ -61,7 +61,7 @@ module GroongaQueryLog
                 parser.parse(input) do |statistic|
                   next if @base_time.nil?
                   next if statistic.start_time < @base_time
-                  if statistic.start_time == @base_time
+                  if statistic.end_time > @base_time
                     yield(statistic)
                   end
                   throw(tag)


### PR DESCRIPTION
Running queries are started after base time and aren't finished at base time.